### PR TITLE
client: make HD related fields of AddressInfo optional

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -498,9 +498,9 @@ pub struct AddressInfo {
     #[serde(rename = "iswitness")]
     pub is_witness: bool,
     #[serde(rename = "hdkeypath")]
-    pub hd_key_path: String,
+    pub hd_key_path: Option<String>,
     #[serde(rename = "hdseedid")]
-    pub hd_seed_id: String,
+    pub hd_seed_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
These fields only get set in some cases 

https://github.com/bitcoin/bitcoin/blob/4036ee3f2bf587775e6f388a9bfd2bcdb8fecf1d/src/wallet/rpc/addresses.cpp#L636-L647